### PR TITLE
Issue #2: Remove brace on package in model.scala

### DIFF
--- a/src/main/scala/com/tsunderebug/scolor/model.scala
+++ b/src/main/scala/com/tsunderebug/scolor/model.scala
@@ -1,11 +1,10 @@
-package com.tsunderebug.scolor {
+package com.tsunderebug.scolor
 
-  object Models {
+object Models {
 
-    import spire.math.UInt
+  import spire.math.UInt
 
-    type Codepoint = UInt
-
-  }
+  type Codepoint = UInt
 
 }
+


### PR DESCRIPTION
While scala allows one to use {} after a package name in order to define
some things in said package, it's uncommon (in my understanding) to use
the braces to encapsulate the whole file like it is in model.scala.

I've removed the braces and fixed the indentation in this commit. 

From a quick grep, it looks like this was only the case in one file

```
grep -H -R package.*{ src/main/scala/com/tsunderebug/scolor/
```

This PR is one step in trying to address #2