### PR TITLE
Use more folds to make more scala-like (avoiding allocations of collections when unnecessary)

### DIFF
--- a/src/main/scala/com/tsunderebug/scolor/otf/tables/OTFNAMETable.scala
+++ b/src/main/scala/com/tsunderebug/scolor/otf/tables/OTFNAMETable.scala
@@ -31,7 +31,7 @@ case class OTFNAMETable(
   }
 
   override def length(b: ByteAllocator): UInt = {
-    records.foldLeft(UInt(6) + strData.length(b)) { // Start with 6 because ???
+    records.foldLeft(UInt(6) + strData.length(b)) { // 6 is the length of the data in bytes before the record data
       case (accum, record) => accum + record(this).length(b)
     }
   }

--- a/src/main/scala/com/tsunderebug/scolor/otf/tables/OpenTypeCMAPTable.scala
+++ b/src/main/scala/com/tsunderebug/scolor/otf/tables/OpenTypeCMAPTable.scala
@@ -20,7 +20,9 @@ case class OpenTypeCMAPTable(
   )
 
   override def length(b: ByteAllocator): UInt = {
-    UInt(sections(b).map(_.data.length(b).toLong).sum)
+    sections(b).foldLeft(UInt(0)) {
+      case (accum, section) => accum + section.data.length(b)
+    }
   }
 
   /**

--- a/src/main/scala/com/tsunderebug/scolor/otf/tables/OpenTypeNAMETable.scala
+++ b/src/main/scala/com/tsunderebug/scolor/otf/tables/OpenTypeNAMETable.scala
@@ -17,11 +17,14 @@ case class OpenTypeNAMETable(
 
   override def sections(b: ByteAllocator): Seq[Section] = {
     val off = b.allocate(this)
-    val dataOff = off.position + UInt(6) + tabeledRecords.map(_.length(b)).toArray.qsum
+    val tabeledRecordsSum = tabeledRecords.foldLeft(UInt(0)) {
+      case (accum, tabledRecord) => accum + tabledRecord.length(b)
+    }
+    val dataOff = off.position + UInt(6) + tabeledRecordsSum
     Seq(
       Section("format", UInt16(UShort(0))),
       Section("count", UInt16(UShort(records.length))),
-      Section("stringOffset", Offset16(6 + tabeledRecords.map(_.length(b)).toArray.qsum.toInt)),
+      Section("stringOffset", Offset16(6 + tabeledRecordsSum.toInt)),
       Section("nameRecords", OTFArray(tabeledRecords)),
       Section("data", strData)
     )

--- a/src/main/scala/com/tsunderebug/scolor/otf/tables/OpenTypeNAMETable.scala
+++ b/src/main/scala/com/tsunderebug/scolor/otf/tables/OpenTypeNAMETable.scala
@@ -30,7 +30,11 @@ case class OpenTypeNAMETable(
     )
   }
 
-  override def length(b: ByteAllocator): UInt = UInt(6) + records.map(_(this).length(b)).toArray.qsum + strData.length(b)
+  override def length(b: ByteAllocator): UInt = {
+    records.foldLeft(UInt(6) + strData.length(b)) { // Start with 6 because ???
+      case (accum, record) => accum + record(this).length(b)
+    }
+  }
 
   /**
     * Gets data sections if this data block has offsets

--- a/src/main/scala/com/tsunderebug/scolor/otf/tables/OpenTypeTable.scala
+++ b/src/main/scala/com/tsunderebug/scolor/otf/tables/OpenTypeTable.scala
@@ -6,7 +6,12 @@ import spire.math.UByte
 
 abstract class OpenTypeTable extends Table {
 
-  override def getBytes(b: ByteAllocator): Array[UByte] = sections(b).flatMap(_.getBytes(b)).toArray
+  override def getBytes(b: ByteAllocator): Array[UByte] = {
+  	sections(b).foldLeft(Array.empty[UByte]) {
+  		case (accum, section) => accum ++ section.getBytes(b)
+  	}
+  }
+  
   def getPosition(b: ByteAllocator): Offset = b.allocate(this)
 
 }

--- a/src/main/scala/com/tsunderebug/scolor/otf/tables/OpenTypeTable.scala
+++ b/src/main/scala/com/tsunderebug/scolor/otf/tables/OpenTypeTable.scala
@@ -7,9 +7,9 @@ import spire.math.UByte
 abstract class OpenTypeTable extends Table {
 
   override def getBytes(b: ByteAllocator): Array[UByte] = {
-  	sections(b).foldLeft(Array.empty[UByte]) {
-  		case (accum, section) => accum ++ section.getBytes(b)
-  	}
+    sections(b).foldLeft(Array.empty[UByte]) {
+      case (accum, section) => accum ++ section.getBytes(b)
+    }
   }
   
   def getPosition(b: ByteAllocator): Offset = b.allocate(this)

--- a/src/main/scala/com/tsunderebug/scolor/otf/types/OTFArray.scala
+++ b/src/main/scala/com/tsunderebug/scolor/otf/types/OTFArray.scala
@@ -7,9 +7,17 @@ import spire.syntax.std.array._
 
 case class OTFArray[T <: Data](elems: Seq[T]) extends SectionDataType {
 
-  override def length(b: ByteAllocator): UInt = elems.map(_.length(b)).toArray.qsum
+  override def length(b: ByteAllocator): UInt = {
+  	elems.foldLeft(UInt(0)) {
+  		case (accum, elem) => accum + elem.length(b)
+  	}
+  }
 
-  override def getBytes(b: ByteAllocator): Array[UByte] = elems.flatMap(_.getBytes(b)).toArray
+  override def getBytes(b: ByteAllocator): Array[UByte] = {
+  	elems.foldLeft(Array.empty[UByte]) {
+  		case (accum, elem) => accum ++ elem.getBytes(b)
+  	}
+  }
 
   /**
     * Gets data sections if this data block has offsets

--- a/src/main/scala/com/tsunderebug/scolor/otf/types/OTFArray.scala
+++ b/src/main/scala/com/tsunderebug/scolor/otf/types/OTFArray.scala
@@ -8,15 +8,15 @@ import spire.syntax.std.array._
 case class OTFArray[T <: Data](elems: Seq[T]) extends SectionDataType {
 
   override def length(b: ByteAllocator): UInt = {
-  	elems.foldLeft(UInt(0)) {
-  		case (accum, elem) => accum + elem.length(b)
-  	}
+    elems.foldLeft(UInt(0)) {
+      case (accum, elem) => accum + elem.length(b)
+    }
   }
 
   override def getBytes(b: ByteAllocator): Array[UByte] = {
-  	elems.foldLeft(Array.empty[UByte]) {
-  		case (accum, elem) => accum ++ elem.getBytes(b)
-  	}
+    elems.foldLeft(Array.empty[UByte]) {
+      case (accum, elem) => accum ++ elem.getBytes(b)
+    }
   }
 
   /**


### PR DESCRIPTION
Following up on Issue comments in #2 with some small refactors to avoid creation of collections that just get turned into `Array`s in order to use `qsum` among other things.