### PR TITLE
Add OTFByteAllocator#allocate tests

### DIFF
--- a/src/test/scala/com/tsunderebug/scolortesting/otf/OTFByteAllocatorTest.scala
+++ b/src/test/scala/com/tsunderebug/scolortesting/otf/OTFByteAllocatorTest.scala
@@ -18,23 +18,24 @@ class OTFByteAllocatorTest extends FlatSpec with PrivateMethodTester {
 
     val nextOffset = otfByteAllocator invokePrivate nextAvailableOffset()
     assertResult(UInt(10))(nextOffset.position)
+    assertResult(OTFOffset32(10))(nextOffset)
   }
 
   it should "return an offset describing the next open space these bytes can fit" in {
     val otfByteAllocator = new OTFByteAllocator(OpenTypeFont(Nil))    
     
     /* first we expect 0 */
-    assertResult(OTFOffset32(0)) {
-      otfByteAllocator.allocate(UInt(10))
-    }
+    val firstOffset = otfByteAllocator.allocate(UInt(10))
+    assertResult(OTFOffset32(0))(firstOffset)
+    assertResult(UInt(0))(firstOffset.position)
 
     /* but after we allocate 10 above, we'll expect to be told we can allocate our
      * next set of bytes to the 10th position (which is 1 higher than our previous
      * allocation since we're 0-based)
      */
-    assertResult(OTFOffset32(10)) {
-      otfByteAllocator.allocate(UInt(6))
-    }
+    val secondOffset = otfByteAllocator.allocate(UInt(6))
+    assertResult(OTFOffset32(10))(secondOffset)
+    assertResult(UInt(10))(secondOffset.position)
   }
   
 }

--- a/src/test/scala/com/tsunderebug/scolortesting/otf/OTFByteAllocatorTest.scala
+++ b/src/test/scala/com/tsunderebug/scolortesting/otf/OTFByteAllocatorTest.scala
@@ -1,0 +1,40 @@
+package com.tsunderebug.scolor.otf
+
+import com.tsunderebug.scolor.Offset
+import com.tsunderebug.scolor.otf.types.OTFOffset32
+
+import spire.math.{UByte, UInt}
+
+import org.scalatest.{FlatSpec, PrivateMethodTester}
+
+class OTFByteAllocatorTest extends FlatSpec with PrivateMethodTester {
+  
+  /* use PrivateMethodTester to access private values in class */
+  val nextAvailableOffset = PrivateMethod[Offset]('nextAvailableOffset)
+
+  "allocate" should "move the next available offset correctly" in {
+    val otfByteAllocator = new OTFByteAllocator(OpenTypeFont(Nil))    
+    otfByteAllocator.allocate(UInt(10))
+
+    val nextOffset = otfByteAllocator invokePrivate nextAvailableOffset()
+    assertResult(UInt(10))(nextOffset.position)
+  }
+
+  it should "return an offset describing the next open space these bytes can fit" in {
+    val otfByteAllocator = new OTFByteAllocator(OpenTypeFont(Nil))    
+    
+    /* first we expect 0 */
+    assertResult(OTFOffset32(0)) {
+      otfByteAllocator.allocate(UInt(10))
+    }
+
+    /* but after we allocate 10 above, we'll expect to be told we can allocate our
+     * next set of bytes to the 10th position (which is 1 higher than our previous
+     * allocation since we're 0-based)
+     */
+    assertResult(OTFOffset32(10)) {
+      otfByteAllocator.allocate(UInt(6))
+    }
+  }
+  
+}


### PR DESCRIPTION
I'm still not entirely sure about everything going on in this, but
figure that the byte allocators seem to have the most logic and it might
make sense to start adding tests around said logic.

I didn't add any tests for the allocate method with the data parameter
because I'm not sure I understand the allocMap's purpose in the file
yet.

I'm still working on understanding the insert method before I add any
sort of test for it. ~But I _think_ I might see a bug in it unless I'm missing
something.~ wait a minute, just realized I missed something important in
those recursive calls to `insert` nevermind about that bug notion I had