### PR TITLE
Refactor mapping in SegmentedCoverageEncodingFormat

### DIFF
--- a/src/main/scala/com/tsunderebug/scolor/otf/types/OTFEncodingRecord.scala
+++ b/src/main/scala/com/tsunderebug/scolor/otf/types/OTFEncodingRecord.scala
@@ -42,13 +42,16 @@ object OTFEncodingRecord {
     */
   case class SegmentedCoverageEncodingFormat(smg: Seq[SequentialMapGroup]) extends EncodingFormat {
 
+    /** Retrieve a map of codepoints to glyph IDs based on the SequentialMapGroup of this instance 
+     * @note Regardless of the encoding scheme, character codes that do not correspond to any glyph in the font are mapped to glyph index 0. The glyph at this location must be a special glyph representing a missing character, commonly known as .notdef.
+     * @return Map of codepoints to glyph ids, as noted any glyphs not defined for a given character code will be 0
+     */
     override def getGlyphEntries: Map[Codepoint, GlyphID] = {
       val emptyGlyph = UInt(0)
       smg.foldLeft(Map.empty[Codepoint, GlyphID]) {
         case (accum, SequentialMapGroup(startCharCode, endCharCode, startGlyphID)) => {
           val glyphRange = (startGlyphID.toLong to (startGlyphID + endCharCode - startCharCode).toLong)
           accum ++ (startCharCode.toLong to endCharCode.toLong).zipWithIndex.map {
-            //"Regardless of the encoding scheme, character codes that do not correspond to any glyph in the font should be mapped to glyph index 0. The glyph at this location must be a special glyph representing a missing character, commonly known as .notdef."
             case (charPoint, index) => UInt(charPoint) -> glyphRange.lift(index).fold(emptyGlyph)(UInt.apply)
           }
         }


### PR DESCRIPTION
This solves issue #12:

Besides removing the flatMap + map + map + toMap, I've made the retrieval of the glyph IDs more safe. Before it was `range.drop(i).head` which was an unsafe operation since .head can produce a `NoSuchElement` exception. I was reading the documentation linked to on the issue and noticed that it said (near the top) that if there is no glyph corresponding with the codepoint, then it should map to 0. So, the drop + head combination becomes `.lift(i)` which gives you an `Option` only filled with a value if the glyph was valid, then this option is folded into a `UInt` or to the default `emptyGlyph`

`fold` is generally a better option than using `getOrElse` when it comes to dealing with Option because it enforces the type safety since there is no upcast.

I did spend a little bit of time reading around the internet to see if there was any concern about building up a map piece by piece like this, but because scala's internals tend to do their best to re-use parts of maps that don't change, then it works out well enough performance wise without having to switch to a mutable Map and using `+=`; so I think the `foldLeft` starting with an empty map then adding the ranges of glyphIds in should be pretty efficient.