### PR TITLE
Add Natural Ordering to SequentialMapGroup

### DIFF
--- a/src/main/scala/com/tsunderebug/scolor/otf/types/OTFEncodingRecord.scala
+++ b/src/main/scala/com/tsunderebug/scolor/otf/types/OTFEncodingRecord.scala
@@ -6,6 +6,7 @@ import com.tsunderebug.scolor.otf.tables.OTFCMAPTable
 import com.tsunderebug.scolor.otf.types.OTFEncodingRecord.EncodingFormat
 import com.tsunderebug.scolor.table.{EnclosingSectionDataType, RequireTable, Section}
 import spire.math.{UInt, UShort}
+import scala.math.Ordered
 
 private[scolor] class TabledEncodingRecord(platformID: UShort, encodingID: UShort, encodingFormat: EncodingFormat, table: OTFCMAPTable) extends EnclosingSectionDataType {
 
@@ -82,7 +83,16 @@ object OTFEncodingRecord {
 
 }
 
-case class SequentialMapGroup(startCodepoint: Codepoint, endCodepoint: Codepoint, startGlyphID: GlyphID) extends EnclosingSectionDataType {
+case class SequentialMapGroup(startCodepoint: Codepoint, endCodepoint: Codepoint, startGlyphID: GlyphID) extends EnclosingSectionDataType with Ordered[SequentialMapGroup] {
+
+  /** Compare this Group to another
+   * @param that The SequentialMapGroup to compare this instance to
+   * @note Groups must be sorted by increasing startCharCode. A group's endCharCode must be less than the startCharCode of the following group, if any. The endCharCode is used, rather than a count, because comparisons for group matching are usually done on an existing character code, and having the endCharCode be there explicitly saves the necessity of an addition per group.
+   * @see https://www.microsoft.com/typography/otspec/cmap.htm#format12
+   */
+  def compare(that: SequentialMapGroup) = {
+    this.startCodepoint.toInt.compare(that.startCodepoint.toInt)
+  }
 
   override def sections(b: ByteAllocator) = Seq(
     Section("startCharCode", OTFUInt32(startCodepoint)),

--- a/src/main/scala/com/tsunderebug/scolor/otf/types/OTFEncodingRecord.scala
+++ b/src/main/scala/com/tsunderebug/scolor/otf/types/OTFEncodingRecord.scala
@@ -62,7 +62,9 @@ object OTFEncodingRecord {
     override def sections(b: ByteAllocator): Seq[Section] = Seq(
       Section("format", OTFUInt16(UShort(12))),
       Section("reserved", OTFUInt16(UShort(0))),
-      Section("length", OTFUInt32(length(b)))
+      Section("length", OTFUInt32(length(b))),
+      Section("numGroups", OTFUInt32(UInt(smg.length))),
+      Section("groups[numGroups]", OTFArray(smg.sorted))
     )
 
     /**

--- a/src/test/scala/com/tsunderebug/scolortesting/otf/types/SequentialMapGroupTest.scala
+++ b/src/test/scala/com/tsunderebug/scolortesting/otf/types/SequentialMapGroupTest.scala
@@ -18,7 +18,7 @@ class SequentialMapGroupTest() extends FlatSpec with OptionValues {
       }
     }
 
-    it should "have a length of 12" in {
+    it should "have a length of 12 bytes (because SequentialMapGroup has 3 sections of 4 bytes each)" in {
       assertResult(UInt(12)) {
         SequentialMapGroup(UInt(1), UInt(5), UInt(0)).length(byteAllocator)
       }

--- a/src/test/scala/com/tsunderebug/scolortesting/otf/types/SequentialMapGroupTest.scala
+++ b/src/test/scala/com/tsunderebug/scolortesting/otf/types/SequentialMapGroupTest.scala
@@ -1,0 +1,42 @@
+package com.tsunderebug.scolor.otf.types
+
+import org.scalatest.{FlatSpec, OptionValues}
+import spire.math.UInt
+
+import com.tsunderebug.scolor.otf.{OTFByteAllocator, OpenTypeFont}
+
+class SequentialMapGroupTest() extends FlatSpec with OptionValues {
+
+  private def byteAllocator = new OTFByteAllocator(OpenTypeFont(Nil))
+
+  "SequentialMapGroup" should "be sorted naturally by their starting character code" in {
+      val range = (0 to 10 by 2)
+      val incorrectlyOrdered = for (i <- range.reverse) yield SequentialMapGroup(UInt(i), UInt(i +1), UInt(0))
+      val correctlyOrdered = for (i <- range) yield SequentialMapGroup(UInt(i), UInt(i +1), UInt(0))
+      assertResult(correctlyOrdered) {
+        incorrectlyOrdered.sorted
+      }
+    }
+
+    it should "have a length of 12" in {
+      assertResult(UInt(12)) {
+        SequentialMapGroup(UInt(1), UInt(5), UInt(0)).length(byteAllocator)
+      }
+    }
+
+    it should "have start and end codepoints and the glyph ID in its sections" in {
+      val startCodePoint = UInt(1)
+      val endCodePoint = UInt(3)
+      val glyphID = UInt(12)
+      val sections = SequentialMapGroup(startCodePoint, endCodePoint, glyphID).sections(byteAllocator)
+      assertResult(OTFUInt32(startCodePoint)) {
+        sections.find(_.name == "startCharCode").value.data
+      }
+      assertResult(OTFUInt32(endCodePoint)) {
+        sections.find(_.name == "endCharCode").value.data
+      }
+      assertResult(OTFUInt32(glyphID)) {
+        sections.find(_.name == "startGlyphID").value.data
+      }
+    }
+}


### PR DESCRIPTION
When I was working on #13 I noticed that [the spec](https://www.microsoft.com/typography/otspec/cmap.htm#format12) said this:

>Groups must be sorted by increasing startCharCode. A group's endCharCode must be less than the startCharCode of the following group, if any. The endCharCode is used, rather than a count, because comparisons for group matching are usually done on an existing character code, and having the endCharCode be there explicitly saves the necessity of an addition per group.

So I was thinking it might make sense to define a natural order for that group class with the `Ordered` trait. So this commit has that and then also has some tests for the class in general including the ordering.

On the part of the spec that says "A group's endCharCode must be less than the startCharCode of the following group" that kinda sounds like the `SegmentedCoverageEncodingFormat` class should throw an IllegalArgumentException or something like that if someone tries to construct an instance of the class and violates that rule. That's not in this commit, but I was thinking about it while I worked on #13 since the exception would probably end up getting thrown from that constructor.
